### PR TITLE
Update README for doc building with poetry, add parallel_map doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ You can build the sphinx documentation locally for the most up-to-date
 reference:
 ```bash
 # Install dependencies
-pip install -r requirements.txt
+poetry install
 # Navigate to the documentation root.
 cd docs
 # Build the docs.
-make html
+poetry run make html
 # Open in your favorite browser!
 firefox _build/html/index.html
 ```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,3 @@
-.. SMQTK documentation master file, created by
-   sphinx-quickstart on Thu Oct 22 16:40:18 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Social Media Query ToolKit -- Descriptors
 =========================================
 
@@ -16,6 +11,7 @@ Data structures and interfaces around generating and storing descriptor (feature
    installation
    descriptor_storage
    descriptor_generation
+   parallelism
    examples
    releasing
 

--- a/docs/parallelism.rst
+++ b/docs/parallelism.rst
@@ -1,0 +1,16 @@
+Parallelism
+===========
+This package provides a parallel work mapping function called
+:meth:`~smqtk_descriptors.utils.parallel.parallel_map` to allow for stream
+parallelism of arbitrary work functions using multi-threading or
+multi-processing.
+Which this method of parallelism is not universally the most efficient, it is
+intended to operate at it's best under situations where work functions are
+dynamic or parallelism with streaming input is required.
+
+Reference
+---------
+.. autofunction:: smqtk_descriptors.utils.parallel.parallel_map
+
+.. autoclass:: smqtk_descriptors.utils.parallel.ParallelResultsIterator
+   :members:


### PR DESCRIPTION
Fixes the top-level README.md quick-start on documentation building to include the use of the poetry tool.

Also adds a documentation page about the added parallelism utility in this package. The tweak to the source file pertains to the function `is_terminal` really being a notionally private function, so the underscore was added to denote this in standard python fashion. This also has the benefit of that function now not showing up in the module auto-documentation (by default hides "private" attributes).