### PR TITLE
deprecating iter functions in interfaces

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -5,6 +5,8 @@ Pending Release Notes
 Updates / New Features
 ----------------------
 
+* Deprecated and renamed various functions with `iter*` prefix because this is
+  no longer a standard. Deprecation warnings were added to preserve usability.
 
 Fixes
 -----

--- a/smqtk_descriptors/impls/descriptor_set/memory.py
+++ b/smqtk_descriptors/impls/descriptor_set/memory.py
@@ -280,11 +280,11 @@ class MemoryDescriptorSet (DescriptorSet):
             self._inner_remove_descriptor(uid, no_cache=True)
         self.cache_table()
 
-    def iterkeys(self) -> Iterator[Hashable]:
+    def keys(self) -> Iterator[Hashable]:
         return iter(self._table.keys())
 
-    def iterdescriptors(self) -> Iterator[DescriptorElement]:
+    def descriptors(self) -> Iterator[DescriptorElement]:
         return iter(self._table.values())
 
-    def iteritems(self) -> Iterator[Tuple[Hashable, DescriptorElement]]:
+    def items(self) -> Iterator[Tuple[Hashable, DescriptorElement]]:
         return iter(self._table.items())

--- a/smqtk_descriptors/impls/descriptor_set/postgres.py
+++ b/smqtk_descriptors/impls/descriptor_set/postgres.py
@@ -319,7 +319,7 @@ class PostgresDescriptorSet (DescriptorSet):
         )
 
         # Transform input into
-        def iter_elements() -> Generator[Dict[str, Any], None, None]:
+        def elements() -> Generator[Dict[str, Any], None, None]:
             for d in descriptors:
                 yield {
                     'uuid_val': str(d.uuid()),
@@ -332,7 +332,7 @@ class PostgresDescriptorSet (DescriptorSet):
             cur.executemany(q, batch)
 
         LOG.debug("Adding many descriptors")
-        list(self.psql_helper.batch_execute(iter_elements(), exec_hook,
+        list(self.psql_helper.batch_execute(elements(), exec_hook,
                                             self.multiquery_batch_size))
 
     def get_descriptor(self, uuid: Hashable) -> DescriptorElement:
@@ -386,7 +386,7 @@ class PostgresDescriptorSet (DescriptorSet):
         # order to raise a KeyError.
         uuid_order = []
 
-        def iterelems() -> Generator[str, None, None]:
+        def elems() -> Generator[str, None, None]:
             for uid in uuids:
                 uuid_order.append(uid)
                 yield str(uid)
@@ -404,7 +404,7 @@ class PostgresDescriptorSet (DescriptorSet):
         #   - We also check that the number of rows we got back is the same
         #     as elements yielded, else there were trailing UUIDs that did not
         #     match anything in the database.
-        g = self.psql_helper.batch_execute(iterelems(), exec_hook,
+        g = self.psql_helper.batch_execute(elems(), exec_hook,
                                            self.multiquery_batch_size,
                                            yield_result_rows=True)
         i = 0
@@ -476,17 +476,17 @@ class PostgresDescriptorSet (DescriptorSet):
 
         list(self.psql_helper.single_execute(execute))
 
-    def iterkeys(self) -> Generator[Hashable, None, None]:
+    def keys(self) -> Generator[Hashable, None, None]:
         """
         Return an iterator over set descriptor keys, which are their UUIDs.
         """
         # Getting UUID through the element because the UUID might not be a
         # string type, and the true type is encoded with the DescriptorElement
         # instance.
-        for d in self.iterdescriptors():
+        for d in self.descriptors():
             yield d.uuid()
 
-    def iterdescriptors(self) -> Generator[DescriptorElement, None, None]:
+    def descriptors(self) -> Generator[DescriptorElement, None, None]:
         """
         Return an iterator over set descriptor element instances.
         """
@@ -504,11 +504,11 @@ class PostgresDescriptorSet (DescriptorSet):
             d = pickle.loads(bytes(r[0]))
             yield d
 
-    def iteritems(self) -> Generator[Tuple[Hashable, DescriptorElement], None, None]:
+    def items(self) -> Generator[Tuple[Hashable, DescriptorElement], None, None]:
         """
         Return an iterator over set descriptor key and instance pairs.
         :rtype: collections.abc.Iterator[(collections.abc.Hashable,
                                           smqtk.representation.DescriptorElement)]
         """
-        for d in self.iterdescriptors():
+        for d in self.descriptors():
             yield d.uuid(), d

--- a/smqtk_descriptors/impls/descriptor_set/solr.py
+++ b/smqtk_descriptors/impls/descriptor_set/solr.py
@@ -300,7 +300,7 @@ class SolrDescriptorSet (DescriptorSet):
         if batch:
             batch_op(batch)
 
-    def iterkeys(self) -> Generator[Hashable, None, None]:
+    def keys(self) -> Generator[Hashable, None, None]:
         """
         Return an iterator over set descriptor keys, which are their UUIDs.
         """
@@ -314,7 +314,7 @@ class SolrDescriptorSet (DescriptorSet):
             for doc in r.results:
                 yield doc[self.d_uid_field]
 
-    def iterdescriptors(self) -> Generator[DescriptorElement, None, None]:
+    def descriptors(self) -> Generator[DescriptorElement, None, None]:
         """
         Return an iterator over set descriptor element instances.
         """
@@ -328,7 +328,7 @@ class SolrDescriptorSet (DescriptorSet):
             for doc in r.results:
                 yield pickle.loads(doc[self.descriptor_field])
 
-    def iteritems(self) -> Generator[Tuple[Hashable, DescriptorElement], None, None]:
+    def items(self) -> Generator[Tuple[Hashable, DescriptorElement], None, None]:
         """
         Return an iterator over set descriptor key and instance pairs.
         """

--- a/smqtk_descriptors/interfaces/descriptor_set.py
+++ b/smqtk_descriptors/interfaces/descriptor_set.py
@@ -1,6 +1,6 @@
 import abc
 from typing import Hashable, Iterable, Iterator, List, Optional, Tuple
-
+from warnings import warn
 import numpy as np
 
 from smqtk_core import Configurable, Pluggable
@@ -26,7 +26,7 @@ class DescriptorSet (Configurable, Pluggable):
         return self.get_descriptor(uuid)
 
     def __iter__(self) -> Iterator[DescriptorElement]:
-        return self.iterdescriptors()
+        return self.descriptors()
 
     def __len__(self) -> int:
         return self.count()
@@ -157,29 +157,38 @@ class DescriptorSet (Configurable, Pluggable):
             DescriptorElement in this index.
 
         """
-
     @abc.abstractmethod
-    def iterkeys(self) -> Iterator[Hashable]:
+    def keys(self) -> Iterator[Hashable]:
         """
         Return an iterator over indexed descriptor keys, which are their UUIDs.
         """
 
     @abc.abstractmethod
-    def iterdescriptors(self) -> Iterator[DescriptorElement]:
+    def descriptors(self) -> Iterator[DescriptorElement]:
         """
         Return an iterator over indexed descriptor element instances.
         """
 
     @abc.abstractmethod
-    def iteritems(self) -> Iterator[Tuple[Hashable, DescriptorElement]]:
+    def items(self) -> Iterator[Tuple[Hashable, DescriptorElement]]:
         """
         Return an iterator over indexed descriptor key and instance pairs.
         """
 
-    def keys(self) -> Iterator[Hashable]:
-        """ alias for iterkeys """
-        return self.iterkeys()
+    def iterkeys(self) -> Iterator[Hashable]:
+        """ Deprecated alias for keys """
+        warn("descriptor_set.iterkeys() deprecated."
+             " Please use keys() instead.", category=DeprecationWarning)
+        return self.keys()
 
-    def items(self) -> Iterator[Tuple[Hashable, DescriptorElement]]:
-        """ alias for iteritems """
-        return self.iteritems()
+    def iterdescriptors(self) -> Iterator[DescriptorElement]:
+        """ Deprecated alias for descriptors """
+        warn("descriptor_set.iterdescriptors() deprecated. Please use"
+             " descriptors() instead", category=DeprecationWarning)
+        return self.descriptors()
+
+    def iteritems(self) -> Iterator[Tuple[Hashable, DescriptorElement]]:
+        """ Deprecated alias for items """
+        warn("descriptor_set.iteritems() deprecated. Please use"
+             " items() instead", category=DeprecationWarning)
+        return self.items()

--- a/tests/impls/descriptor_set/test_memory.py
+++ b/tests/impls/descriptor_set/test_memory.py
@@ -286,19 +286,19 @@ class TestMemoryDescriptorSet (unittest.TestCase):
         descrs = [random_descriptor() for _ in range(100)]
         i.add_many_descriptors(descrs)
         self.assertEqual(len(i), 100)
-        self.assertEqual(list(i.iterdescriptors()), descrs)
+        self.assertEqual(list(i.descriptors()), descrs)
 
         # remove singles
         i.remove_descriptor(descrs[0].uuid())
         self.assertEqual(len(i), 99)
-        self.assertEqual(set(i.iterdescriptors()),
+        self.assertEqual(set(i.descriptors()),
                          set(descrs[1:]))
 
         # remove many
         rm_d = descrs[slice(45, 80, 3)]
         i.remove_many_descriptors((d.uuid() for d in rm_d))
         self.assertEqual(len(i), 99 - len(rm_d))
-        self.assertEqual(set(i.iterdescriptors()),
+        self.assertEqual(set(i.descriptors()),
                          set(descrs[1:]).difference(rm_d))
 
     def test_natural_iter(self) -> None:
@@ -310,21 +310,21 @@ class TestMemoryDescriptorSet (unittest.TestCase):
         self.assertEqual(set(i),
                          set(descrs))
 
-    def test_iterdescrs(self) -> None:
+    def test_descrs(self) -> None:
         i = MemoryDescriptorSet()
         descrs = [random_descriptor() for _ in range(100)]
         i.add_many_descriptors(descrs)
-        self.assertEqual(set(i.iterdescriptors()),
+        self.assertEqual(set(i.descriptors()),
                          set(descrs))
 
-    def test_iterkeys(self) -> None:
+    def test_keys(self) -> None:
         i = MemoryDescriptorSet()
         descrs = [random_descriptor() for _ in range(100)]
         i.add_many_descriptors(descrs)
-        self.assertEqual(set(i.iterkeys()),
+        self.assertEqual(set(i.keys()),
                          set(d.uuid() for d in descrs))
 
-    def test_iteritems(self) -> None:
+    def test_items(self) -> None:
         i = MemoryDescriptorSet()
         descrs = [random_descriptor() for _ in range(100)]
         i.add_many_descriptors(descrs)

--- a/tests/interfaces/test_descriptor_set.py
+++ b/tests/interfaces/test_descriptor_set.py
@@ -16,13 +16,13 @@ class DummyDescriptorSet (DescriptorSet):
     def get_many_descriptors(self, uuids: Iterable[Hashable]) -> Iterator[DescriptorElement]:
         pass
 
-    def iterkeys(self) -> Iterator[Hashable]:
+    def keys(self) -> Iterator[Hashable]:
         pass
 
-    def iteritems(self) -> Iterator[Tuple[Hashable, DescriptorElement]]:
+    def items(self) -> Iterator[Tuple[Hashable, DescriptorElement]]:
         pass
 
-    def iterdescriptors(self) -> Iterator[DescriptorElement]:
+    def descriptors(self) -> Iterator[DescriptorElement]:
         pass
 
     def remove_many_descriptors(self, uuids: Iterable[Hashable]) -> None:
@@ -80,13 +80,13 @@ class TestDescriptorSetAbstract (unittest.TestCase):
                 yield _i
 
         # noinspection PyTypeHints
-        di.iterdescriptors = mock.Mock(side_effect=dumb_iterator)  # type: ignore
+        di.descriptors = mock.Mock(side_effect=dumb_iterator)  # type: ignore
 
         for i, v in enumerate(iter(di)):
             self.assertEqual(i, v)
         self.assertEqual(list(di), [0, 1, 2])
         self.assertEqual(tuple(di), (0, 1, 2))
-        self.assertEqual(di.iterdescriptors.call_count, 3)
+        self.assertEqual(di.descriptors.call_count, 3)
 
     @mock.patch("smqtk_descriptors.interfaces.descriptor_set.DescriptorElement"
                 ".get_many_vectors", wraps=DescriptorElement.get_many_vectors)


### PR DESCRIPTION
purpose of this PR is to add deprecation warnings to the uses of iter* functions in the descriptors interfaces