### PR TITLE
Add test coverage reporting options

### DIFF
--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -120,4 +120,4 @@ jobs:
             poetry install --extras "$OPT_EXTRA"
           fi
       - name: Run Unittests
-        run: poetry run pytest --cov=smqtk_descriptors --cov-config=.pytest.coveragerc
+        run: poetry run pytest

--- a/.pytest.coveragerc
+++ b/.pytest.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = tests/*

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -17,6 +17,13 @@ Misc.
 
 * Add PyTorch descriptor generator implementation
 
+Testing
+
+* Updated pytest configuration to cover package + tests, add report output
+  options.
+
+* Removed or no-cover mark dead lines of code.
+
 Fixes
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,13 @@ jedi = "^0.17.2"
 ###############################################################################
 [tool.pytest.ini_options]
 addopts = [
-    "-lv",                  # Show local in trace-backs.
-    "--doctest-modules",    # Increased verbosity.
-    "--tb=long",            # Trace-back print mode.
+    "-lv",                          # Show local in trace-backs.
+    "--doctest-modules",            # Increased verbosity.
+    "--tb=long",                    # Trace-back print mode.
+    "--cov=./smqtk_descriptors",    # Cover our package specifically
+    "--cov=./tests",                # Also cover our tests for dead spots
+    "--cov-report=term",            # Coverage report to terminal
+    "--cov-report=xml:coverage.xml" # for external tool reporting
 ]
 testpaths = [
     "tests",

--- a/tests/impls/descriptor_generator/test_image_descriptor_generator_wrapper.py
+++ b/tests/impls/descriptor_generator/test_image_descriptor_generator_wrapper.py
@@ -24,14 +24,12 @@ class StubImageReader (ImageReader):
         self,
         data_element: DataElement,
         pixel_crop: Optional[AxisAlignedBoundingBox] = None
-    ) -> Optional[np.ndarray]:
-        return iter([])
+    ) -> Optional[np.ndarray]: ...
 
     def get_config(self) -> Dict:
         return {}
 
-    def valid_content_types(self) -> Set:
-        return set()
+    def valid_content_types(self) -> Set: ...
 
 
 class StubImageDG (ImageDescriptorGenerator):
@@ -39,8 +37,7 @@ class StubImageDG (ImageDescriptorGenerator):
     def generate_arrays_from_images(
         self,
         img_mat_iter: Iterable[np.ndarray]
-    ) -> Iterable[np.ndarray]:
-        return iter([])
+    ) -> Iterable[np.ndarray]: ...
 
     def get_config(self) -> Dict[str, Any]:
         return {}

--- a/tests/interfaces/test_descriptor_generator.py
+++ b/tests/interfaces/test_descriptor_generator.py
@@ -24,11 +24,9 @@ class DummyDescriptorGenerator (DescriptorGenerator):
         # Stub "method" for testing functionality is called post-final-yield.
         self._post_iterator_check = mock.Mock()
 
-    def get_config(self) -> Dict[str, Any]:
-        return {}
+    def get_config(self) -> Dict[str, Any]: ...
 
-    def valid_content_types(self) -> Set[str]:
-        return set()
+    def valid_content_types(self) -> Set[str]: ...
 
     def _generate_arrays(self, data_iter: Iterable[DataElement]) -> Iterable[numpy.ndarray]:
         # Make sure we go through iter, yielding "arrays"
@@ -43,8 +41,9 @@ class DummyDescriptorGenerator (DescriptorGenerator):
         for i, d in enumerate(data_iter):
             yield [i]
         yield [-1]
-        yield [-2]
-        self._post_iterator_check()
+        # The following lines should not be run in the context of test usage.
+        yield [-2]  # pragma: no cover
+        self._post_iterator_check()  # pragma: no cover
 
     def _generate_too_few_arrays(self, data_iter: Iterable[DataElement]) -> Generator:
         """

--- a/tests/interfaces/test_descriptor_set.py
+++ b/tests/interfaces/test_descriptor_set.py
@@ -7,44 +7,31 @@ from smqtk_descriptors import DescriptorElement, DescriptorSet
 
 class DummyDescriptorSet (DescriptorSet):
 
-    def get_config(self) -> Dict[str, Any]:
-        pass
+    def get_config(self) -> Dict[str, Any]: ...
 
-    def get_descriptor(self, uuid: Hashable) -> DescriptorElement:
-        pass
+    def get_descriptor(self, uuid: Hashable) -> DescriptorElement: ...
 
-    def get_many_descriptors(self, uuids: Iterable[Hashable]) -> Iterator[DescriptorElement]:
-        pass
+    def get_many_descriptors(self, uuids: Iterable[Hashable]) -> Iterator[DescriptorElement]: ...
 
-    def keys(self) -> Iterator[Hashable]:
-        pass
+    def keys(self) -> Iterator[Hashable]: ...
 
-    def items(self) -> Iterator[Tuple[Hashable, DescriptorElement]]:
-        pass
+    def items(self) -> Iterator[Tuple[Hashable, DescriptorElement]]: ...
 
-    def descriptors(self) -> Iterator[DescriptorElement]:
-        pass
+    def descriptors(self) -> Iterator[DescriptorElement]: ...
 
-    def remove_many_descriptors(self, uuids: Iterable[Hashable]) -> None:
-        pass
+    def remove_many_descriptors(self, uuids: Iterable[Hashable]) -> None: ...
 
-    def has_descriptor(self, uuid: Hashable) -> bool:
-        pass
+    def has_descriptor(self, uuid: Hashable) -> bool: ...
 
-    def add_many_descriptors(self, descriptors: Iterable[DescriptorElement]) -> None:
-        pass
+    def add_many_descriptors(self, descriptors: Iterable[DescriptorElement]) -> None: ...
 
-    def count(self) -> int:
-        pass
+    def count(self) -> int: ...
 
-    def clear(self) -> None:
-        pass
+    def clear(self) -> None: ...
 
-    def remove_descriptor(self, uuid: Hashable) -> None:
-        pass
+    def remove_descriptor(self, uuid: Hashable) -> None: ...
 
-    def add_descriptor(self, descriptor: DescriptorElement) -> None:
-        pass
+    def add_descriptor(self, descriptor: DescriptorElement) -> None: ...
 
 
 class TestDescriptorSetAbstract (unittest.TestCase):

--- a/tests/test_descriptor_element_factory.py
+++ b/tests/test_descriptor_element_factory.py
@@ -14,17 +14,13 @@ class DummyElementImpl (DescriptorElement):
         self.args = args
         self.kwds = kwds
 
-    def set_vector(self, new_vec: numpy.ndarray) -> "DummyElementImpl":
-        return self
+    def set_vector(self, new_vec: numpy.ndarray) -> "DummyElementImpl": ...
 
-    def has_vector(self) -> bool:
-        pass
+    def has_vector(self) -> bool: ...
 
-    def vector(self) -> Optional[numpy.ndarray]:
-        pass
+    def vector(self) -> Optional[numpy.ndarray]: ...
 
-    def get_config(self) -> Dict[str, Any]:
-        pass
+    def get_config(self) -> Dict[str, Any]: ...
 
 
 class TestDescriptorElemFactory (unittest.TestCase):


### PR DESCRIPTION
This adds to `pyproject.toml` pytest arguments block to include the `--cov` specifications as well as some coverage output options: terminal and `coverage.xml` file. The `coverage.xml` file is already included in the `.gitignore`.