### PR TITLE
Add prepopulated descriptor generator

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -4,6 +4,8 @@ Pending Release Notes
 Updates / New Features
 ----------------------
 
+* Add prepopulated descriptor generator
+
 Fixes
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ ipython = ">=7.16.3"
 # DescriptorGenerator
 "smqtk_descriptors.impls.descriptor_generator.caffe1" = "smqtk_descriptors.impls.descriptor_generator.caffe1"
 "smqtk_descriptors.impls.descriptor_generator.pytorch" = "smqtk_descriptors.impls.descriptor_generator.pytorch"
+"smqtk_descriptors.impls.descriptor_generator.prepopulated" = "smqtk_descriptors.impls.descriptor_generator.prepopulated"
 # DescriptorSet
 "smqtk_descriptors.impls.descriptor_set.memory" = "smqtk_descriptors.impls.descriptor_set.memory"
 "smqtk_descriptors.impls.descriptor_set.postgres" = "smqtk_descriptors.impls.descriptor_set.postgres"

--- a/smqtk_descriptors/impls/descriptor_generator/prepopulated.py
+++ b/smqtk_descriptors/impls/descriptor_generator/prepopulated.py
@@ -1,0 +1,34 @@
+import logging
+import numpy as np
+from typing import Any, Dict, Iterable, Set, TypeVar
+
+from smqtk_dataprovider import DataElement
+from smqtk_descriptors import DescriptorGenerator
+
+LOG = logging.getLogger(__name__)
+
+__all__ = ["PrePopulatedDescriptorGenerator"]
+T = TypeVar("T", bound="PrePopulatedDescriptorGenerator")
+
+
+class PrePopulatedDescriptorGenerator(DescriptorGenerator):
+    """
+    This class is to be used in the config when the descriptor set is already
+    prepopulated.  This allows, for example, an IQR process where the
+    descriptors are already known or have been previously generated using some
+    external process. Calling the _generate_arrays() method will not work and
+    will raise an AssertionError.
+    """
+
+    def valid_content_types(self) -> Set:
+        return set()
+
+    def _generate_arrays(
+        self, data_iter: Iterable[DataElement]
+    ) -> Iterable[np.ndarray]:
+        raise AssertionError(
+            "Method should not be called since descriptors are prepopulated."
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        return {}

--- a/tests/impls/descriptor_generator/test_prepopulated.py
+++ b/tests/impls/descriptor_generator/test_prepopulated.py
@@ -1,0 +1,30 @@
+import pytest
+from smqtk_descriptors.impls.descriptor_generator.prepopulated import (
+    PrePopulatedDescriptorGenerator,
+)
+
+
+def test_valid_content_types() -> None:
+    """
+    Tests that valid_content_types() returns an empty set.
+    """
+    generator = PrePopulatedDescriptorGenerator()
+    assert generator.valid_content_types() == set()
+
+
+def test_generate_arrays() -> None:
+    """
+    Tests that _generate_arrays() method raises AssertionError.
+    """
+    generator = PrePopulatedDescriptorGenerator()
+
+    with pytest.raises(AssertionError):
+        generator._generate_arrays([])
+
+
+def test_get_config() -> None:
+    """
+    Tests that get_config() returns an empty dictionary.
+    """
+    generator = PrePopulatedDescriptorGenerator()
+    assert generator.get_config() == {}


### PR DESCRIPTION
Add a module/ class for a `PrePopulatedDescriptorGenerator` to use when descriptors are already generated and prepopulated into a descriptor set.
- modified `pyproject.toml` to  add the new descriptor generator module.
- created `prepopulated` implementation of descriptor generator and the class `PrepopulatedDescriptorGenerator`.
- created an in-progress `test_prepopulated.py` file